### PR TITLE
Increase opencode CLI installation wait time from 2s to 60s

### DIFF
--- a/coder/template/main.tf
+++ b/coder/template/main.tf
@@ -386,7 +386,7 @@ resource "coder_script" "opencode_serve" {
         exit 1
       fi
       echo "Waiting for opencode CLI to be installed... (attempt $attempt/$max_attempts)"
-      sleep 2
+      sleep 60
     done
 
     echo "Starting opencode serve on port 62748..."


### PR DESCRIPTION
## Summary
Increased the sleep interval in the opencode CLI installation retry loop from 2 seconds to 60 seconds to provide more time for the installation process to complete between retry attempts.

## Changes
- Modified the retry loop sleep duration in the `coder_script` resource from `sleep 2` to `sleep 60`
- This gives the opencode CLI installation process a full minute between retry attempts instead of just 2 seconds

## Details
The opencode CLI installation may require more time to complete, especially in environments with slower network connectivity or system resources. The previous 2-second wait was likely too aggressive and could result in unnecessary retry attempts. Increasing this to 60 seconds allows the installation to progress more naturally while still maintaining the retry mechanism for genuine failures.

https://claude.ai/code/session_0143wYsMVN5UQXD9y3TKMHZs