### PR TITLE
Add opencode bin directory to PATH in startup script

### DIFF
--- a/coder/template/main.tf
+++ b/coder/template/main.tf
@@ -376,6 +376,9 @@ resource "coder_script" "opencode_serve" {
     #!/bin/bash
     set -e
 
+    # Add opencode install path to PATH
+    export PATH="/home/coder/.opencode/bin:$PATH"
+
     # Wait for opencode to be installed by the module
     max_attempts=30
     attempt=0


### PR DESCRIPTION
## Summary
Updated the opencode_serve startup script to include the opencode installation directory in the system PATH, ensuring that opencode binaries are accessible during script execution.

## Changes
- Added `/home/coder/.opencode/bin` to the PATH environment variable at the beginning of the opencode_serve script
- This ensures opencode command-line tools are available before the installation wait loop executes

## Implementation Details
The PATH export is placed early in the script (after `set -e`) to guarantee that any subsequent commands can locate opencode binaries. This is particularly important for the installation verification logic that follows, as it may need to check for or execute opencode commands.

https://claude.ai/code/session_01EJP2dvkgnKTygAZDWxdvwd