### PR TITLE
chore: initialize turborepo monorepo with pnpm workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# dependencies
+node_modules/
+.pnpm-store/
+
+# next.js
+.next/
+out/
+
+# turbo
+.turbo/
+
+# build
+dist/
+*.tsbuildinfo
+
+# env files
+.env
+.env.local
+.env.*.local
+
+# vercel
+.vercel/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pve-home-lab",
+  "private": true,
+  "scripts": {
+    "dev": "turbo dev",
+    "build": "turbo build",
+    "lint": "turbo lint"
+  },
+  "devDependencies": {
+    "turbo": "^2.8.0"
+  },
+  "packageManager": "pnpm@10.28.2"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,78 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      turbo:
+        specifier: ^2.8.0
+        version: 2.8.0
+
+packages:
+
+  turbo-darwin-64@2.8.0:
+    resolution: {integrity: sha512-N7f4PYqz25yk8c5kituk09bJ89tE4wPPqKXgYccT6nbEQnGnrdvlyCHLyqViNObTgjjrddqjb1hmDkv7VcxE0g==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.8.0:
+    resolution: {integrity: sha512-eVzejaP5fn51gmJAPW68U6mSjFaAZ26rPiE36mMdk+tMC4XBGmJHT/fIgrhcrXMvINCl27RF8VmguRe+MBlSuQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.8.0:
+    resolution: {integrity: sha512-ILR45zviYae3icf4cmUISdj8X17ybNcMh3Ms4cRdJF5sS50qDDTv8qeWqO/lPeHsu6r43gVWDofbDZYVuXYL7Q==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.8.0:
+    resolution: {integrity: sha512-z9pUa8ENFuHmadPfjEYMRWlXO82t1F/XBDx2XTg+cWWRZHf85FnEB6D4ForJn/GoKEEvwdPhFLzvvhOssom2ug==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.8.0:
+    resolution: {integrity: sha512-J6juRSRjmSErEqJCv7nVIq2DgZ2NHXqyeV8NQTFSyIvrThKiWe7FDOO6oYpuR06+C1NW82aoN4qQt4/gYvz25w==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.8.0:
+    resolution: {integrity: sha512-qarBZvCu6uka35739TS+y/3CBU3zScrVAfohAkKHG+So+93Wn+5tKArs8HrO2fuTaGou8fMIeTV7V5NgzCVkSQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.8.0:
+    resolution: {integrity: sha512-hYbxnLEdvJF+DLALS+Ia+PbfNtn0sDP0hH2u9AFoskSUDmcVHSrtwHpzdX94MrRJKo9D9tYxY3MyP20gnlrWyA==}
+    hasBin: true
+
+snapshots:
+
+  turbo-darwin-64@2.8.0:
+    optional: true
+
+  turbo-darwin-arm64@2.8.0:
+    optional: true
+
+  turbo-linux-64@2.8.0:
+    optional: true
+
+  turbo-linux-arm64@2.8.0:
+    optional: true
+
+  turbo-windows-64@2.8.0:
+    optional: true
+
+  turbo-windows-arm64@2.8.0:
+    optional: true
+
+  turbo@2.8.0:
+    optionalDependencies:
+      turbo-darwin-64: 2.8.0
+      turbo-darwin-arm64: 2.8.0
+      turbo-linux-64: 2.8.0
+      turbo-linux-arm64: 2.8.0
+      turbo-windows-64: 2.8.0
+      turbo-windows-arm64: 2.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Initialize Turborepo + pnpm workspaces to prepare the repo for a monorepo structure
- Add root `package.json`, `turbo.json`, `pnpm-workspace.yaml`, and `.gitignore`
- Workspace directories configured: `apps/*` and `packages/*`

## Files Added

| File | Purpose |
|------|---------|
| `package.json` | Root workspace config (`private: true`, turbo scripts, `packageManager` field) |
| `pnpm-workspace.yaml` | Defines `apps/*` and `packages/*` workspaces |
| `turbo.json` | Pipeline config for `build`, `dev`, `lint` tasks |
| `.gitignore` | Ignores `node_modules`, `.next`, `.turbo`, `dist`, env files |
| `pnpm-lock.yaml` | Lockfile generated by `pnpm install` |

## Verification

- `pnpm install` completes successfully
- `pnpm turbo build` and `pnpm turbo lint` run cleanly (0 packages in scope — expected until workspace apps are added)
- `node_modules/` and `.turbo/` properly excluded by `.gitignore`

Closes #9