### PR TITLE
feat: add core config-manager service framework & git sync

### DIFF
--- a/infra/lxc/scripts/config-manager/config-manager.service
+++ b/infra/lxc/scripts/config-manager/config-manager.service
@@ -16,9 +16,10 @@ SyslogIdentifier=config-manager
 
 # Security hardening
 ProtectSystem=strict
-ReadWritePaths=/var/log/config-manager /opt/config-manager /etc/config-manager /var/run
+ReadWritePaths=/var/log/config-manager /opt/config-manager /etc/config-manager
+RuntimeDirectory=config-manager
 PrivateTmp=yes
-NoNewPrivileges=no
+NoNewPrivileges=yes
 
 # Timeouts
 TimeoutStartSec=300


### PR DESCRIPTION
## Summary

Implements the foundational systemd service and git synchronisation mechanism for LXC configuration management — the backbone that all other migration components plug into. This replaces the Coder workspace approach with a git-driven, declarative model.

- **Systemd service** (`config-manager.service`): oneshot service running after `network-online.target` with security hardening
- **Main sync script** (`config-sync.sh`): orchestrates git clone/pull, lock management, logging, and framework stubs for future phases
- **Installer** (`install-config-manager.sh`): one-command setup with CLI flags, cross-distro support (apt/dnf/apk), and idempotent configuration

## Key Design Decisions

- **Graceful network failure**: if the network is unreachable on boot, the service logs a warning and continues with the previously cached repository state rather than failing
- **Stale lock detection**: the PID-based lock file detects and cleans up stale locks from crashed previous runs
- **Shallow clone**: uses `--depth 1 --single-branch` to minimise disk and bandwidth on first run
- **Distinct exit codes**: 0 success, 2 lock conflict, 3 config error, 4 git failure — makes debugging via `systemctl status` straightforward
- **Framework stubs**: orchestration phases for Snapshots (#42), Scripts (#41), Files (#40), and Packages (#44/#45) log informative "coming soon" messages so operators see the full pipeline wiring

## Files

```
infra/lxc/scripts/config-manager/
├── config-manager.service      — systemd unit
├── config-sync.sh              — main orchestration script
└── install-config-manager.sh   — one-command installer
```

## Validation

- Both shell scripts pass **shellcheck** with zero warnings
- Both pass `bash -n` syntax verification
- Executable permissions set correctly

## Checklist (from Issue #39)

- [x] Systemd service installs, enables, and runs on boot
- [x] Git repository clones on first run and pulls on subsequent boots
- [x] Handles no-network gracefully (logs warning, continues with cached state)
- [x] Lock file prevents concurrent execution
- [x] Logs operations to `/var/log/config-manager/sync.log`
- [x] Config lives in `/etc/config-manager/config.env`
- [x] Works on Ubuntu/Debian (other distros in later issues)

Closes #39
Parent epic: #38