### PR TITLE
Brand refresh: Rename pve-home-lab to infrahaus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# PVE Home Lab
+# Infrahaus
 
 A self-hosted home lab built on [Proxmox VE](https://www.proxmox.com/en/proxmox-virtual-environment/overview), running Docker-based services across AI/ML, media, gaming, blockchain, and development workloads. Everything is defined as code and documented with a [Fumadocs](https://fumadocs.vercel.app/) site.
 
 ## Monorepo Structure
 
 ```
-pve-home-lab/
+infrahaus/
 ├── apps/
 │   └── web/                 # Documentation site (Next.js + Fumadocs)
 ├── infra/                   # Infrastructure configurations
@@ -33,8 +33,8 @@ pve-home-lab/
 
 ```bash
 # Clone the repository
-git clone https://github.com/kethalia/pve-home-lab.git
-cd pve-home-lab
+git clone https://github.com/kethalia/infrahaus.git
+cd infrahaus
 
 # Install dependencies
 pnpm install

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -86,7 +86,7 @@ export default function HomePage() {
           Self-hosted infrastructure as code
         </div>
         <h1 className="mb-6 max-w-3xl text-5xl font-bold leading-tight tracking-tight sm:text-6xl">
-          PVE Home Lab
+          Infrahaus
         </h1>
         <p className="mb-10 max-w-2xl text-lg text-fd-muted-foreground leading-relaxed">
           A Proxmox VE home lab running Docker-based services across AI/ML,
@@ -201,11 +201,11 @@ export default function HomePage() {
       <footer className="border-t border-fd-border px-6 py-8">
         <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 sm:flex-row">
           <p className="text-sm text-fd-muted-foreground">
-            PVE Home Lab &mdash; Self-hosted infrastructure as code
+            Infrahaus &mdash; Self-hosted infrastructure as code
           </p>
           <div className="flex items-center gap-6">
             <a
-              href="https://github.com/kethalia/pve-home-lab"
+              href="https://github.com/kethalia/infrahaus"
               target="_blank"
               rel="noopener noreferrer"
               className="text-sm text-fd-muted-foreground transition-colors hover:text-fd-foreground"

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,8 +5,8 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: {
-    template: "%s | PVE Home Lab",
-    default: "PVE Home Lab",
+    template: "%s | Infrahaus",
+    default: "Infrahaus",
   },
   description:
     "Documentation for a Proxmox VE home lab with AI, media, gaming, blockchain, and development services.",

--- a/apps/web/content/docs/container-templates/configuration.mdx
+++ b/apps/web/content/docs/container-templates/configuration.mdx
@@ -26,7 +26,7 @@ config-manager.service (systemd)
 
 ```bash
 # Git repository settings
-CONFIG_REPO_URL="https://github.com/kethalia/pve-home-lab.git"
+CONFIG_REPO_URL="https://github.com/kethalia/infrahaus.git"
 CONFIG_BRANCH="main"
 CONFIG_PATH="infra/lxc/templates/web3-dev/container-configs"
 CONFIG_HELPER_PATH="infra/lxc/scripts/config-manager"
@@ -351,4 +351,4 @@ CONFIG_PATH="my-custom-path/configs"
 
 For the complete configuration reference including detailed examples, all configuration options, and troubleshooting, see:
 
-**[infra/lxc/docs/CONFIGURATION.md](https://github.com/kethalia/pve-home-lab/blob/main/infra/lxc/docs/CONFIGURATION.md)**
+**[infra/lxc/docs/CONFIGURATION.md](https://github.com/kethalia/infrahaus/blob/main/infra/lxc/docs/CONFIGURATION.md)**

--- a/apps/web/content/docs/container-templates/credentials.mdx
+++ b/apps/web/content/docs/container-templates/credentials.mdx
@@ -12,7 +12,7 @@ LXC templates implement a secure credential management system with randomly gene
 ### Security Features
 
 - **Random Generation**: 16-character alphanumeric passwords generated on first boot
-- **Secure Storage**: Credentials stored in `/etc/pve-home-lab/credentials` (mode 600, root-only)
+- **Secure Storage**: Credentials stored in `/etc/infrahaus/credentials` (mode 600, root-only)
 - **Unique Per Container**: Each container has different passwords
 - **No Defaults**: No hardcoded passwords like "admin" or "coder"
 - **Easy Retrieval**: Simple commands to view credentials from host or container
@@ -33,7 +33,7 @@ All web services use password authentication:
 
 ```bash
 # View all credentials
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+pct exec <container-id> -- cat /etc/infrahaus/credentials
 
 # Watch welcome banner (includes credentials)
 pct exec <container-id> -- journalctl -u config-manager -f --no-pager -o cat
@@ -43,7 +43,7 @@ pct exec <container-id> -- journalctl -u config-manager -f --no-pager -o cat
 
 ```bash
 # View credentials (requires root/sudo)
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 
 # Check welcome message
 cat /etc/motd
@@ -161,7 +161,7 @@ sudo systemctl restart opencode@coder
 After changing passwords, optionally update the reference file:
 
 ```bash
-sudo vim /etc/pve-home-lab/credentials
+sudo vim /etc/infrahaus/credentials
 ```
 
 **Note:** The credentials file is for reference only. Each service stores passwords independently.
@@ -258,7 +258,7 @@ sudo passwd
 
 ### Credentials File Not Found
 
-**Symptom:** `/etc/pve-home-lab/credentials` doesn't exist
+**Symptom:** `/etc/infrahaus/credentials` doesn't exist
 
 **Cause:** Config-manager hasn't completed first boot
 
@@ -286,7 +286,7 @@ sudo systemctl restart config-manager
 2. **Wrong credential retrieved:**
 
    ```bash
-   grep CODE_SERVER_PASSWORD /etc/pve-home-lab/credentials
+   grep CODE_SERVER_PASSWORD /etc/infrahaus/credentials
    ```
 
 3. **Password contains special characters:**
@@ -332,7 +332,7 @@ sudo systemctl status code-server@coder
 1. **Retrieve from container:**
 
    ```bash
-   pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+   pct exec <container-id> -- cat /etc/infrahaus/credentials
    ```
 
 2. **Reset passwords** (follow password change procedures above)
@@ -341,7 +341,7 @@ sudo systemctl status code-server@coder
    ```bash
    # WARNING: This resets all services
    pct enter <container-id>
-   sudo rm /etc/pve-home-lab/credentials
+   sudo rm /etc/infrahaus/credentials
    sudo systemctl restart config-manager
    ```
 
@@ -353,7 +353,7 @@ sudo systemctl status code-server@coder
 
 ```bash
 # From ProxmoxVE host
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials > container-<container-id>-creds.txt
+pct exec <container-id> -- cat /etc/infrahaus/credentials > container-<container-id>-creds.txt
 
 # Encrypt for storage
 gpg -c container-<container-id>-creds.txt
@@ -370,7 +370,7 @@ gpg -c container-<container-id>-creds.txt
 pct enter <new-container-id>
 
 # Regenerate credentials
-sudo rm /etc/pve-home-lab/credentials
+sudo rm /etc/infrahaus/credentials
 sudo systemctl restart config-manager
 
 # Or manually change all passwords

--- a/apps/web/content/docs/container-templates/index.mdx
+++ b/apps/web/content/docs/container-templates/index.mdx
@@ -27,7 +27,7 @@ ProxmoxVE Host
 │   │   ├── Script Execution (00-pre-checks.sh → 99-post-setup.sh)
 │   │   ├── File Management (bashrc, aliases, gitconfig)
 │   │   ├── Package Installation (apt, npm, pip, custom)
-│   │   ├── Credential Generation (/etc/pve-home-lab/credentials)
+│   │   ├── Credential Generation (/etc/infrahaus/credentials)
 │   │   └── Snapshot System (ZFS/LVM/BTRFS/file-level)
 │   ├── Installed Tools (Docker, Node.js, etc.)
 │   ├── User Environment (coder:1000)
@@ -54,7 +54,7 @@ ProxmoxVE Host
 
 ```bash
 # From ProxmoxVE host:
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ### Custom Resources
@@ -62,7 +62,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/ma
 ```bash
 # 2 CPU, 4GB RAM, 30GB disk
 var_cpu=2 var_ram=4096 var_disk=30 \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ### Custom Repository
@@ -71,7 +71,7 @@ var_cpu=2 var_ram=4096 var_disk=30 \
 # Use your own config fork
 REPO_URL="https://github.com/yourusername/your-configs.git" \
 REPO_BRANCH="main" \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ## Available Templates
@@ -154,7 +154,7 @@ foundry|command -v forge|curl -L https://foundry.paradigm.xyz | bash && foundryu
 All web services (VS Code Server, FileBrowser, OpenCode) use randomly generated passwords:
 
 - **16-character alphanumeric passwords** generated on first boot
-- **Stored securely** in `/etc/pve-home-lab/credentials` (mode 600, root-only)
+- **Stored securely** in `/etc/infrahaus/credentials` (mode 600, root-only)
 - **Unique per container** - no hardcoded defaults
 - **Easy retrieval** from ProxmoxVE host or inside container
 
@@ -162,10 +162,10 @@ All web services (VS Code Server, FileBrowser, OpenCode) use randomly generated 
 
 ```bash
 # From ProxmoxVE host
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+pct exec <container-id> -- cat /etc/infrahaus/credentials
 
 # Inside container
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 ```
 
 ### Unprivileged Containers
@@ -324,8 +324,8 @@ See [Troubleshooting](/docs/container-templates/troubleshooting) for detailed so
 
 ### Report Issues
 
-- **GitHub Issues**: https://github.com/kethalia/pve-home-lab/issues
-- **Discussions**: https://github.com/kethalia/pve-home-lab/discussions
+- **GitHub Issues**: https://github.com/kethalia/infrahaus/issues
+- **Discussions**: https://github.com/kethalia/infrahaus/discussions
 
 ### Improve Documentation
 

--- a/apps/web/content/docs/container-templates/migration.mdx
+++ b/apps/web/content/docs/container-templates/migration.mdx
@@ -352,4 +352,4 @@ newgrp docker
 
 For the complete migration guide including more source types, detailed examples, and troubleshooting, see:
 
-**[infra/lxc/docs/MIGRATION.md](https://github.com/kethalia/pve-home-lab/blob/main/infra/lxc/docs/MIGRATION.md)**
+**[infra/lxc/docs/MIGRATION.md](https://github.com/kethalia/infrahaus/blob/main/infra/lxc/docs/MIGRATION.md)**

--- a/apps/web/content/docs/container-templates/setup.mdx
+++ b/apps/web/content/docs/container-templates/setup.mdx
@@ -22,7 +22,7 @@ The LXC template system provides a declarative, git-based approach to creating a
 From your ProxmoxVE host shell:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 **Duration**: 5-10 minutes
@@ -32,12 +32,12 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/ma
 ```bash
 # Custom resources: 2 CPU, 4GB RAM, 30GB disk
 var_cpu=2 var_ram=4096 var_disk=30 \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 
 # Custom repository and branch
 REPO_URL="https://github.com/yourusername/your-fork.git" \
 REPO_BRANCH="develop" \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ## Resource Requirements
@@ -65,15 +65,15 @@ REPO_BRANCH="develop" \
 ssh root@proxmox-host
 
 # Run template script
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ### Method 2: Manual Installation
 
 ```bash
 # Clone repository
-git clone https://github.com/kethalia/pve-home-lab.git
-cd pve-home-lab/infra/lxc/templates/web3-dev
+git clone https://github.com/kethalia/infrahaus.git
+cd infrahaus/infra/lxc/templates/web3-dev
 
 # Review template.conf (optional)
 cat template.conf
@@ -133,7 +133,7 @@ All web services use randomly generated passwords created during first boot. Ret
 
 ```bash
 # View credentials file
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+pct exec <container-id> -- cat /etc/infrahaus/credentials
 
 # Or watch the welcome banner
 pct exec <container-id> -- journalctl -u config-manager -f --no-pager -o cat
@@ -143,7 +143,7 @@ pct exec <container-id> -- journalctl -u config-manager -f --no-pager -o cat
 
 ```bash
 # View credentials (requires root/sudo)
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 
 # Or check welcome message
 cat /etc/motd
@@ -186,7 +186,7 @@ REPO_BRANCH="main" \
 
 ### Creating Custom Templates
 
-See the [full setup documentation](https://github.com/kethalia/pve-home-lab/blob/main/infra/lxc/docs/SETUP.md#creating-custom-templates) for detailed instructions on creating your own templates.
+See the [full setup documentation](https://github.com/kethalia/infrahaus/blob/main/infra/lxc/docs/SETUP.md#creating-custom-templates) for detailed instructions on creating your own templates.
 
 ## Next Steps
 
@@ -198,4 +198,4 @@ See the [full setup documentation](https://github.com/kethalia/pve-home-lab/blob
 
 For the complete setup guide including detailed examples, customization options, and advanced topics, see:
 
-**[infra/lxc/docs/SETUP.md](https://github.com/kethalia/pve-home-lab/blob/main/infra/lxc/docs/SETUP.md)**
+**[infra/lxc/docs/SETUP.md](https://github.com/kethalia/infrahaus/blob/main/infra/lxc/docs/SETUP.md)**

--- a/apps/web/content/docs/container-templates/troubleshooting.mdx
+++ b/apps/web/content/docs/container-templates/troubleshooting.mdx
@@ -64,7 +64,7 @@ ls -la /run/config-manager/config-manager.lock
 
 ```bash
 sudo tee /etc/config-manager/config.env <<EOF
-CONFIG_REPO_URL="https://github.com/kethalia/pve-home-lab.git"
+CONFIG_REPO_URL="https://github.com/kethalia/infrahaus.git"
 CONFIG_BRANCH="main"
 CONFIG_PATH="infra/lxc/templates/web3-dev/container-configs"
 SNAPSHOT_ENABLED="auto"
@@ -476,7 +476,7 @@ journalctl -u config-manager -n 200 | grep -E 'took|Installing'
 
 ### Credentials File Missing
 
-**Symptom**: `/etc/pve-home-lab/credentials` doesn't exist
+**Symptom**: `/etc/infrahaus/credentials` doesn't exist
 
 **Cause**: Config-manager hasn't completed first boot setup
 
@@ -504,7 +504,7 @@ sudo systemctl restart config-manager
 
 ```bash
 # Verify credentials file exists and is readable
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 
 # Check service is running
 systemctl status code-server@coder
@@ -522,7 +522,7 @@ sudo cat /etc/systemd/system/code-server@.service | grep PASSWORD
 sudo systemctl restart code-server@coder
 
 # If still not working, regenerate credentials
-sudo rm /etc/pve-home-lab/credentials
+sudo rm /etc/infrahaus/credentials
 sudo systemctl restart config-manager
 ```
 
@@ -709,11 +709,11 @@ When reporting issues, include:
 
 ### Where to Ask
 
-- **GitHub Issues**: https://github.com/kethalia/pve-home-lab/issues
-- **Discussions**: https://github.com/kethalia/pve-home-lab/discussions
+- **GitHub Issues**: https://github.com/kethalia/infrahaus/issues
+- **Discussions**: https://github.com/kethalia/infrahaus/discussions
 
 ## Full Documentation
 
 For the complete troubleshooting guide with detailed examples and solutions, see:
 
-**[infra/lxc/docs/TROUBLESHOOTING.md](https://github.com/kethalia/pve-home-lab/blob/main/infra/lxc/docs/TROUBLESHOOTING.md)**
+**[infra/lxc/docs/TROUBLESHOOTING.md](https://github.com/kethalia/infrahaus/blob/main/infra/lxc/docs/TROUBLESHOOTING.md)**

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: PVE Home Lab
+title: Infrahaus
 description: Documentation for a Proxmox VE home lab running Docker-based services across AI, media, gaming, blockchain, and development workloads.
 ---
 
@@ -52,4 +52,4 @@ Proxmox VE Host
 
 ## Source Code
 
-All infrastructure configurations live in the [`infra/`](https://github.com/kethalia/pve-home-lab/tree/main/infra) directory of the repository, organized by service.
+All infrastructure configurations live in the [`infra/`](https://github.com/kethalia/infrahaus/tree/main/infra) directory of the repository, organized by service.

--- a/apps/web/lib/layout.shared.tsx
+++ b/apps/web/lib/layout.shared.tsx
@@ -3,8 +3,8 @@ import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: "PVE Home Lab",
+      title: "Infrahaus",
     },
-    githubUrl: "https://github.com/kethalia/pve-home-lab",
+    githubUrl: "https://github.com/kethalia/infrahaus",
   };
 }

--- a/infra/lxc/docs/CONFIGURATION.md
+++ b/infra/lxc/docs/CONFIGURATION.md
@@ -196,7 +196,7 @@ This file controls all aspects of config-manager behavior. It's created during i
 
 ```bash
 # /etc/config-manager/config.env
-CONFIG_REPO_URL="https://github.com/kethalia/pve-home-lab.git"
+CONFIG_REPO_URL="https://github.com/kethalia/infrahaus.git"
 CONFIG_BRANCH="main"
 CONFIG_PATH="infra/lxc/templates/web3-dev/container-configs"
 CONFIG_HELPER_PATH="infra/lxc/scripts/config-manager"
@@ -218,10 +218,10 @@ LVM_SNAPSHOT_SIZE="1G"
 
 ```bash
 # HTTPS (recommended for public repos)
-CONFIG_REPO_URL="https://github.com/kethalia/pve-home-lab.git"
+CONFIG_REPO_URL="https://github.com/kethalia/infrahaus.git"
 
 # SSH (for private repos with key authentication)
-CONFIG_REPO_URL="git@github.com:kethalia/pve-home-lab.git"
+CONFIG_REPO_URL="git@github.com:kethalia/infrahaus.git"
 
 # Self-hosted GitLab
 CONFIG_REPO_URL="https://gitlab.example.com/infra/configs.git"

--- a/infra/lxc/docs/SETUP.md
+++ b/infra/lxc/docs/SETUP.md
@@ -47,7 +47,7 @@ From your ProxmoxVE host shell (SSH into Proxmox):
 
 ```bash
 # Deploy web3-dev template with defaults
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 **What happens:**
@@ -68,16 +68,16 @@ Override defaults using environment variables:
 ```bash
 # Custom resources: 2 CPU, 4GB RAM, 30GB disk
 var_cpu=2 var_ram=4096 var_disk=30 \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 
 # Custom git repository and branch
 REPO_URL="https://github.com/yourusername/your-fork.git" \
 REPO_BRANCH="develop" \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 
 # Unprivileged container (no Docker-in-Docker)
 var_unprivileged=1 \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ### Available Templates
@@ -145,7 +145,7 @@ This is the fastest method and requires no manual steps:
 ssh root@proxmox-host
 
 # Run the template's container.sh script
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 **Environment Variables**:
@@ -174,8 +174,8 @@ For more control or when troubleshooting:
 
 ```bash
 # Clone the repository
-git clone https://github.com/kethalia/pve-home-lab.git
-cd pve-home-lab/infra/lxc/templates/web3-dev
+git clone https://github.com/kethalia/infrahaus.git
+cd infrahaus/infra/lxc/templates/web3-dev
 ```
 
 #### Step 2: Review and Customize template.conf
@@ -433,7 +433,7 @@ To use a fork or custom repository:
 # Deploy with custom repo
 REPO_URL="https://github.com/yourusername/your-configs.git" \
 REPO_BRANCH="main" \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 **Repository structure required**:
@@ -462,7 +462,7 @@ Each template has its own `container-configs/` directory. To customize:
 # Fork the repository on GitHub
 # Clone your fork
 git clone https://github.com/yourusername/pve-home-lab.git
-cd pve-home-lab/infra/lxc/templates/web3-dev/container-configs
+cd infrahaus/infra/lxc/templates/web3-dev/container-configs
 
 # Add your packages
 echo "vim" >> packages/base.apt
@@ -568,7 +568,7 @@ EOF
 cp infra/lxc/templates/web3-dev/container.sh infra/lxc/templates/my-template/
 
 # Or download the shared pattern
-curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh \
+curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh \
   -o infra/lxc/templates/my-template/container.sh
 ```
 
@@ -705,5 +705,5 @@ pct exec <container-id> -- config-rollback status
 ### Getting Help
 
 - **Documentation**: See [CONFIGURATION.md](CONFIGURATION.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
-- **GitHub Issues**: https://github.com/kethalia/pve-home-lab/issues
-- **Discussions**: https://github.com/kethalia/pve-home-lab/discussions
+- **GitHub Issues**: https://github.com/kethalia/infrahaus/issues
+- **Discussions**: https://github.com/kethalia/infrahaus/discussions

--- a/infra/lxc/docs/TROUBLESHOOTING.md
+++ b/infra/lxc/docs/TROUBLESHOOTING.md
@@ -165,7 +165,7 @@ ping -c 3 github.com
 ```bash
 # If config file is missing, recreate it
 sudo tee /etc/config-manager/config.env <<EOF
-CONFIG_REPO_URL="https://github.com/kethalia/pve-home-lab.git"
+CONFIG_REPO_URL="https://github.com/kethalia/infrahaus.git"
 CONFIG_BRANCH="main"
 CONFIG_PATH="infra/lxc/templates/web3-dev/container-configs"
 SNAPSHOT_ENABLED="auto"
@@ -247,7 +247,7 @@ sudo systemctl restart config-manager
 ```bash
 # Recreate config file
 sudo tee /etc/config-manager/config.env <<EOF
-CONFIG_REPO_URL="https://github.com/kethalia/pve-home-lab.git"
+CONFIG_REPO_URL="https://github.com/kethalia/infrahaus.git"
 CONFIG_BRANCH="main"
 CONFIG_PATH="infra/lxc/templates/web3-dev/container-configs"
 SNAPSHOT_ENABLED="auto"
@@ -1531,8 +1531,8 @@ When reporting issues, include:
 
 ### Where to Ask
 
-- **GitHub Issues**: https://github.com/kethalia/pve-home-lab/issues
-- **GitHub Discussions**: https://github.com/kethalia/pve-home-lab/discussions
+- **GitHub Issues**: https://github.com/kethalia/infrahaus/issues
+- **GitHub Discussions**: https://github.com/kethalia/infrahaus/discussions
 
 ### Contributing Fixes
 

--- a/infra/lxc/scripts/README.md
+++ b/infra/lxc/scripts/README.md
@@ -70,7 +70,7 @@ Web3 development environment with Docker-in-Docker support.
 **Quick Start:**
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 **Includes:**
@@ -182,11 +182,11 @@ All follow the same structure but with different packages.
 
 ```bash
 # Default configuration
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 
 # Custom resources
 var_cpu=2 var_ram=4096 var_disk=30 \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ### Using Custom Repository
@@ -195,7 +195,7 @@ var_cpu=2 var_ram=4096 var_disk=30 \
 # Point to your fork
 REPO_URL="https://github.com/myuser/my-fork.git" \
 REPO_BRANCH="develop" \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ### Container Management
@@ -228,7 +228,7 @@ journalctl -u config-manager -f
 
 ### Reporting Issues
 
-Report issues at: https://github.com/kethalia/pve-home-lab/issues
+Report issues at: https://github.com/kethalia/infrahaus/issues
 
 ### Contributing Templates
 
@@ -247,4 +247,4 @@ The config-manager system is designed to be generic and reusable. Improvements s
 
 ## License
 
-MIT - See [LICENSE](https://github.com/kethalia/pve-home-lab/blob/main/LICENSE)
+MIT - See [LICENSE](https://github.com/kethalia/infrahaus/blob/main/LICENSE)

--- a/infra/lxc/scripts/config-manager/config-manager-helpers.sh
+++ b/infra/lxc/scripts/config-manager/config-manager-helpers.sh
@@ -332,13 +332,13 @@ generate_password() {
 # Usage: save_credential "KEY" "value"
 #        save_credential "CODE_SERVER_PASSWORD" "aB3dEf7hIjKl"
 #
-# Creates /etc/pve-home-lab/credentials with mode 600 (root-only) and
+# Creates /etc/infrahaus/credentials with mode 600 (root-only) and
 # appends key=value pairs for use by other scripts and welcome messages.
 # ---------------------------------------------------------------------------
 save_credential() {
     local key="$1"
     local value="$2"
-    local creds_file="/etc/pve-home-lab/credentials"
+    local creds_file="/etc/infrahaus/credentials"
     
     # Ensure directory exists
     mkdir -p "$(dirname "$creds_file")"

--- a/infra/lxc/scripts/config-manager/config-manager.service
+++ b/infra/lxc/scripts/config-manager/config-manager.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=LXC Configuration Manager - Git-based config sync
-Documentation=https://github.com/kethalia/pve-home-lab
+Documentation=https://github.com/kethalia/infrahaus
 After=network-online.target
 Wants=network-online.target
 

--- a/infra/lxc/scripts/config-manager/install-config-manager.sh
+++ b/infra/lxc/scripts/config-manager/install-config-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Defaults
 # ---------------------------------------------------------------------------
-readonly DEFAULT_REPO_URL="https://github.com/kethalia/pve-home-lab.git"
+readonly DEFAULT_REPO_URL="https://github.com/kethalia/infrahaus.git"
 readonly DEFAULT_BRANCH="main"
 readonly DEFAULT_CONFIG_PATH="infra/lxc/container-configs"
 

--- a/infra/lxc/scripts/install-lxc-template.sh
+++ b/infra/lxc/scripts/install-lxc-template.sh
@@ -9,8 +9,8 @@
 
 # Copyright (c) 2026 kethalia  
 # Author: kethalia
-# License: MIT | https://github.com/kethalia/pve-home-lab/raw/main/LICENSE
-# Source: https://github.com/kethalia/pve-home-lab
+# License: MIT | https://github.com/kethalia/infrahaus/raw/main/LICENSE
+# Source: https://github.com/kethalia/infrahaus
 
 source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
 color
@@ -21,7 +21,7 @@ network_check
 update_os
 
 # Configuration (must be provided via environment variables by container.sh)
-REPO_URL="${REPO_URL:-https://github.com/kethalia/pve-home-lab.git}"
+REPO_URL="${REPO_URL:-https://github.com/kethalia/infrahaus.git}"
 REPO_BRANCH="${REPO_BRANCH:-main}"
 
 # Use the same branch for config-manager as the installation script
@@ -79,7 +79,7 @@ msg_ok "Configuration file created"
 # Download config-sync.sh
 msg_info "Downloading config-sync script"
 if ! curl -fsSL --max-time 60 -A "ProxmoxVE-Script/1.0" \
-    "https://raw.githubusercontent.com/kethalia/pve-home-lab/${REPO_BRANCH}/infra/lxc/scripts/config-manager/config-sync.sh" \
+    "https://raw.githubusercontent.com/kethalia/infrahaus/${REPO_BRANCH}/infra/lxc/scripts/config-manager/config-sync.sh" \
     -o /usr/local/bin/config-sync.sh; then
   msg_error "Failed to download config-sync.sh"
   exit 1
@@ -102,7 +102,7 @@ msg_ok "Config-sync script installed"
 # Download systemd service file
 msg_info "Downloading systemd service file"
 if ! curl -fsSL --max-time 60 -A "ProxmoxVE-Script/1.0" \
-    "https://raw.githubusercontent.com/kethalia/pve-home-lab/${REPO_BRANCH}/infra/lxc/scripts/config-manager/config-manager.service" \
+    "https://raw.githubusercontent.com/kethalia/infrahaus/${REPO_BRANCH}/infra/lxc/scripts/config-manager/config-manager.service" \
     -o /etc/systemd/system/config-manager.service; then
   msg_error "Failed to download config-manager.service"
   exit 1
@@ -220,7 +220,7 @@ echo -e "${INFO}${YW}Follow config-manager logs from host:${CL}"
 echo -e "${TAB}${BGN}pct exec ${CTID} -- journalctl -u config-manager -f --no-pager -o cat${CL}"
 echo -e ""
 echo -e "${INFO}${YW}View web app credentials (generated passwords):${CL}"
-echo -e "${TAB}${BGN}pct exec ${CTID} -- cat /etc/pve-home-lab/credentials${CL}"
+echo -e "${TAB}${BGN}pct exec ${CTID} -- cat /etc/infrahaus/credentials${CL}"
 echo -e ""
 echo -e "${INFO}${YW}Config Management (from inside container):${CL}"
 echo -e "${TAB}• Manual sync: ${BGN}sudo systemctl restart config-manager${CL}"

--- a/infra/lxc/templates/web3-dev/CREDENTIALS.md
+++ b/infra/lxc/templates/web3-dev/CREDENTIALS.md
@@ -16,7 +16,7 @@ The Web3 Development Container template implements a secure credential managemen
 
 ### Credential Storage
 
-**File Location:** `/etc/pve-home-lab/credentials`
+**File Location:** `/etc/infrahaus/credentials`
 
 **Permissions:**
 
@@ -59,7 +59,7 @@ generate_password() {
 **View credentials file:**
 
 ```bash
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+pct exec <container-id> -- cat /etc/infrahaus/credentials
 ```
 
 **Example output:**
@@ -83,13 +83,13 @@ pct exec <container-id> -- journalctl -u config-manager -f --no-pager -o cat
 **As root:**
 
 ```bash
-cat /etc/pve-home-lab/credentials
+cat /etc/infrahaus/credentials
 ```
 
 **As coder user:**
 
 ```bash
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 ```
 
 **View welcome message:**
@@ -104,7 +104,7 @@ cat /etc/motd
 2. **Wait for config-manager** to complete (2-5 minutes)
 3. **Retrieve credentials** from ProxmoxVE host:
    ```bash
-   pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+   pct exec <container-id> -- cat /etc/infrahaus/credentials
    ```
 4. **Save credentials** in password manager (recommended)
 5. **Access web services** using retrieved passwords
@@ -123,7 +123,7 @@ cat /etc/motd
 **View current password:**
 
 ```bash
-sudo cat /etc/pve-home-lab/credentials | grep CODE_SERVER_PASSWORD
+sudo cat /etc/infrahaus/credentials | grep CODE_SERVER_PASSWORD
 ```
 
 **Change password (Method 1 - Plaintext):**
@@ -164,7 +164,7 @@ sudo systemctl restart code-server@coder
 **Update credentials file (optional):**
 
 ```bash
-sudo vim /etc/pve-home-lab/credentials
+sudo vim /etc/infrahaus/credentials
 # Update: CODE_SERVER_PASSWORD=your-new-password
 ```
 
@@ -179,7 +179,7 @@ sudo vim /etc/pve-home-lab/credentials
 **View current credentials:**
 
 ```bash
-sudo cat /etc/pve-home-lab/credentials | grep FILEBROWSER
+sudo cat /etc/infrahaus/credentials | grep FILEBROWSER
 ```
 
 **Change password via CLI:**
@@ -206,7 +206,7 @@ sudo systemctl status filebrowser
 **Update credentials file (optional):**
 
 ```bash
-sudo vim /etc/pve-home-lab/credentials
+sudo vim /etc/infrahaus/credentials
 # Update: FILEBROWSER_PASSWORD=new-password
 ```
 
@@ -220,7 +220,7 @@ sudo vim /etc/pve-home-lab/credentials
 **View current password:**
 
 ```bash
-sudo cat /etc/pve-home-lab/credentials | grep OPENCODE_PASSWORD
+sudo cat /etc/infrahaus/credentials | grep OPENCODE_PASSWORD
 ```
 
 **Change password:**
@@ -243,7 +243,7 @@ sudo systemctl status opencode@coder
 **Update credentials file (optional):**
 
 ```bash
-sudo vim /etc/pve-home-lab/credentials
+sudo vim /etc/infrahaus/credentials
 # Update: OPENCODE_PASSWORD=new-password
 ```
 
@@ -366,7 +366,7 @@ If you've lost your credentials:
 
 ```bash
 # From ProxmoxVE host
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+pct exec <container-id> -- cat /etc/infrahaus/credentials
 ```
 
 **Option 2: Reset passwords**
@@ -382,7 +382,7 @@ Follow the service-specific password change procedures above, then update the cr
 pct enter <container-id>
 
 # Remove old credentials
-sudo rm /etc/pve-home-lab/credentials
+sudo rm /etc/infrahaus/credentials
 
 # Re-run configuration scripts
 sudo systemctl restart config-manager
@@ -393,14 +393,14 @@ journalctl -u config-manager -f
 
 ### Credentials File Corrupted
 
-If `/etc/pve-home-lab/credentials` is corrupted:
+If `/etc/infrahaus/credentials` is corrupted:
 
 ```bash
 # Enter container
 pct enter <container-id>
 
 # Manually recreate file
-sudo tee /etc/pve-home-lab/credentials << 'EOF'
+sudo tee /etc/infrahaus/credentials << 'EOF'
 # Generated credentials for Web3 Dev Container
 CODE_SERVER_PASSWORD=your-password-here
 FILEBROWSER_USERNAME=admin
@@ -409,8 +409,8 @@ OPENCODE_PASSWORD=your-password-here
 EOF
 
 # Set correct permissions
-sudo chmod 600 /etc/pve-home-lab/credentials
-sudo chown root:root /etc/pve-home-lab/credentials
+sudo chmod 600 /etc/infrahaus/credentials
+sudo chown root:root /etc/infrahaus/credentials
 
 # Verify each service uses these passwords
 # Follow service-specific password change procedures if needed
@@ -466,7 +466,7 @@ watch -n 1 'ss -tnp | grep ":808"'
 
 ### Credentials File Not Found
 
-**Symptom:** `/etc/pve-home-lab/credentials` doesn't exist
+**Symptom:** `/etc/infrahaus/credentials` doesn't exist
 
 **Cause:** Config-manager hasn't completed initial setup
 
@@ -495,7 +495,7 @@ sudo systemctl restart config-manager
 # The credentials file is for reference only
 # Each service stores passwords independently
 # Update the credentials file to match actual passwords
-sudo vim /etc/pve-home-lab/credentials
+sudo vim /etc/infrahaus/credentials
 ```
 
 ### Password Not Working
@@ -515,14 +515,14 @@ sudo vim /etc/pve-home-lab/credentials
 
    ```bash
    # Ensure you're reading the correct credential
-   grep CODE_SERVER_PASSWORD /etc/pve-home-lab/credentials
+   grep CODE_SERVER_PASSWORD /etc/infrahaus/credentials
    ```
 
 3. **Password contains special characters:**
 
    ```bash
    # Check if password has quotes or spaces
-   cat /etc/pve-home-lab/credentials
+   cat /etc/infrahaus/credentials
    # Copy-paste exactly as shown
    ```
 
@@ -563,7 +563,7 @@ sudo vim /etc/systemd/system/code-server@.service
 
 ```bash
 # From ProxmoxVE host
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials > container-<container-id>-credentials.txt
+pct exec <container-id> -- cat /etc/infrahaus/credentials > container-<container-id>-credentials.txt
 
 # Store securely (encrypt if committing to git)
 gpg -c container-<container-id>-credentials.txt
@@ -588,7 +588,7 @@ gpg -c container-<container-id>-credentials.txt
 ```bash
 # After cloning, regenerate credentials
 pct enter <new-container-id>
-sudo rm /etc/pve-home-lab/credentials
+sudo rm /etc/infrahaus/credentials
 sudo systemctl restart config-manager
 
 # Or manually change passwords for each service
@@ -604,6 +604,6 @@ sudo systemctl restart config-manager
 
 For issues or questions:
 
-- GitHub Issues: https://github.com/kethalia/pve-home-lab/issues
+- GitHub Issues: https://github.com/kethalia/infrahaus/issues
 - Check troubleshooting section above
 - Review config-manager logs: `journalctl -u config-manager`

--- a/infra/lxc/templates/web3-dev/README.md
+++ b/infra/lxc/templates/web3-dev/README.md
@@ -26,7 +26,7 @@ Note: install.sh is now shared across all templates at:
 
 ```bash
 # From ProxmoxVE host shell:
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ### Custom Configuration
@@ -34,16 +34,16 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/ma
 ```bash
 # Custom resources (2 CPU, 4GB RAM, 30GB disk)
 var_cpu=2 var_ram=4096 var_disk=30 \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 
 # Custom repository and branch
 REPO_URL="https://github.com/myuser/my-fork.git" \
 REPO_BRANCH="develop" \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/main/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/main/infra/lxc/templates/web3-dev/container.sh)"
 
 # Test feature branch (for developers)
 SCRIPT_BRANCH="feature/my-changes" \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/feature/my-changes/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/feature/my-changes/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 ## Container Specifications
@@ -62,7 +62,7 @@ SCRIPT_BRANCH="feature/my-changes" \
   - 8080: VS Code Server (password-protected)
   - 8081: FileBrowser (password-protected)
   - 8082: OpenCode (password-protected)
-- **Security:** Random passwords generated on first boot, stored in `/etc/pve-home-lab/credentials`
+- **Security:** Random passwords generated on first boot, stored in `/etc/infrahaus/credentials`
 
 ### Customizable via Environment Variables
 
@@ -128,7 +128,7 @@ Automatically installed from `container-configs/packages/`:
   - Modern web-based editing experience
   - Password-protected (random password on first boot)
 
-**Credentials:** All passwords are randomly generated during container setup and stored in `/etc/pve-home-lab/credentials` (mode 600, root-only). See [Credentials & Security](#credentials--security) section.
+**Credentials:** All passwords are randomly generated during container setup and stored in `/etc/infrahaus/credentials` (mode 600, root-only). See [Credentials & Security](#credentials--security) section.
 
 ## Configuration Management
 
@@ -164,7 +164,7 @@ web3-dev/container-configs/
 This template implements a secure credential management system:
 
 - **Random Generation:** All passwords are randomly generated (16 characters, A-Za-z0-9) during first boot
-- **Secure Storage:** Credentials stored in `/etc/pve-home-lab/credentials` (mode 600, root-only access)
+- **Secure Storage:** Credentials stored in `/etc/infrahaus/credentials` (mode 600, root-only access)
 - **No Defaults:** No hardcoded passwords - each container has unique credentials
 - **Easy Access:** Credentials displayed in welcome banner and accessible via simple commands
 
@@ -174,7 +174,7 @@ This template implements a secure credential management system:
 
 ```bash
 # View all credentials
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+pct exec <container-id> -- cat /etc/infrahaus/credentials
 
 # Stream welcome message with credentials
 pct exec <container-id> -- journalctl -u config-manager -f --no-pager -o cat
@@ -184,7 +184,7 @@ pct exec <container-id> -- journalctl -u config-manager -f --no-pager -o cat
 
 ```bash
 # View credentials file directly (requires root)
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 
 # Or use the welcome message command
 cat /etc/motd
@@ -244,7 +244,7 @@ sudo systemctl restart opencode@coder
 
 ```bash
 # Update stored credentials for reference
-sudo vim /etc/pve-home-lab/credentials
+sudo vim /etc/infrahaus/credentials
 ```
 
 ### Security Best Practices
@@ -302,10 +302,10 @@ OpenCode:         http://<container-ip>:8082
 
 ```bash
 # From ProxmoxVE host
-pct exec <container-id> -- cat /etc/pve-home-lab/credentials
+pct exec <container-id> -- cat /etc/infrahaus/credentials
 
 # Inside container
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 ```
 
 **Features:**
@@ -319,7 +319,7 @@ sudo cat /etc/pve-home-lab/credentials
 
 **First Time Setup:**
 
-1. Retrieve credentials: `pct exec <container-id> -- cat /etc/pve-home-lab/credentials`
+1. Retrieve credentials: `pct exec <container-id> -- cat /etc/infrahaus/credentials`
 2. Open `http://<container-ip>:8080` in your browser
 3. Enter the `CODE_SERVER_PASSWORD` from credentials file
 4. Open folder: `/home/coder`
@@ -548,7 +548,7 @@ ufw status
 **Common Issues:**
 
 - **Can't access port 8080:** Check if code-server is running: `systemctl status code-server@coder`
-- **Password not working:** Get credentials: `sudo cat /etc/pve-home-lab/credentials`
+- **Password not working:** Get credentials: `sudo cat /etc/infrahaus/credentials`
 - **Credentials file missing:** Wait for config-manager to complete: `journalctl -u config-manager -f`
 - **Port conflicts:** Ensure ports 8080-8082 are not already in use: `ss -tlnp | grep ':808'`
 - **VS Code extensions not loading:** Check EXTENSIONS_GALLERY is set: `cat /etc/environment | grep EXTENSIONS`
@@ -621,7 +621,7 @@ pct set <container-id> -net0 name=eth0,bridge=vmbr0,firewall=1,ip=dhcp
 
 ### Reporting Issues
 
-Report issues at: https://github.com/kethalia/pve-home-lab/issues
+Report issues at: https://github.com/kethalia/infrahaus/issues
 
 ### Creating Templates
 
@@ -633,7 +633,7 @@ Share your custom templates by:
 
 ## License
 
-MIT - See [LICENSE](https://github.com/kethalia/pve-home-lab/blob/main/LICENSE)
+MIT - See [LICENSE](https://github.com/kethalia/infrahaus/blob/main/LICENSE)
 
 ## Related Documentation
 

--- a/infra/lxc/templates/web3-dev/TESTING.md
+++ b/infra/lxc/templates/web3-dev/TESTING.md
@@ -171,11 +171,11 @@ From ProxmoxVE host:
 
 ```bash
 # Deploy using the web3-dev template
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/feat/proxmox-lxc-clean/infra/lxc/templates/web3-dev/container.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/feat/proxmox-lxc-clean/infra/lxc/templates/web3-dev/container.sh)"
 
 # Or with custom resources
 var_cpu=2 var_ram=4096 var_disk=20 \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/feat/proxmox-lxc-clean/infra/lxc/templates/web3-dev/container.sh)"
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/feat/proxmox-lxc-clean/infra/lxc/templates/web3-dev/container.sh)"
 ```
 
 2. **Monitor installation:**
@@ -229,17 +229,17 @@ echo $PATH
 
 ```bash
 # Verify credentials file exists
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 
 # Check file permissions
-ls -l /etc/pve-home-lab/credentials
+ls -l /etc/infrahaus/credentials
 # Should show: -rw------- 1 root root
 
 # Verify all required credentials present
-grep -E "CODE_SERVER_PASSWORD|FILEBROWSER_USERNAME|FILEBROWSER_PASSWORD|OPENCODE_PASSWORD" /etc/pve-home-lab/credentials
+grep -E "CODE_SERVER_PASSWORD|FILEBROWSER_USERNAME|FILEBROWSER_PASSWORD|OPENCODE_PASSWORD" /etc/infrahaus/credentials
 
 # Check password format (should be 16 chars, alphanumeric)
-sudo grep CODE_SERVER_PASSWORD /etc/pve-home-lab/credentials | cut -d'=' -f2 | wc -c
+sudo grep CODE_SERVER_PASSWORD /etc/infrahaus/credentials | cut -d'=' -f2 | wc -c
 # Should output: 17 (16 chars + newline)
 ```
 
@@ -253,7 +253,7 @@ echo "FileBrowser: http://${CONTAINER_IP}:8081"
 echo "OpenCode: http://${CONTAINER_IP}:8082"
 
 # Get credentials
-sudo cat /etc/pve-home-lab/credentials
+sudo cat /etc/infrahaus/credentials
 
 # Test from external machine
 curl -I http://${CONTAINER_IP}:8080
@@ -343,7 +343,7 @@ ls /home/coder/.local/share/code-server/extensions/ | grep -i "juanblanco.solidi
 
 ### Credentials & Security
 
-- [ ] /etc/pve-home-lab/credentials file exists
+- [ ] /etc/infrahaus/credentials file exists
 - [ ] Credentials file has correct permissions (600, root:root)
 - [ ] All required credentials present (CODE*SERVER_PASSWORD, FILEBROWSER*\*, OPENCODE_PASSWORD)
 - [ ] Passwords are 16 characters, alphanumeric

--- a/infra/lxc/templates/web3-dev/container-configs/scripts/50-vscode-server.sh
+++ b/infra/lxc/templates/web3-dev/container-configs/scripts/50-vscode-server.sh
@@ -6,7 +6,7 @@
 # - Custom settings (OLED theme, Fira Code, etc.)
 # - Random secure password
 #
-# Service exposed on port 8080 with password stored in /etc/pve-home-lab/credentials
+# Service exposed on port 8080 with password stored in /etc/infrahaus/credentials
 
 set -eo pipefail
 

--- a/infra/lxc/templates/web3-dev/container-configs/scripts/51-filebrowser.sh
+++ b/infra/lxc/templates/web3-dev/container-configs/scripts/51-filebrowser.sh
@@ -6,7 +6,7 @@
 # - Root directory set to container user's home
 # - Web interface on port 8081
 #
-# Credentials stored in /etc/pve-home-lab/credentials
+# Credentials stored in /etc/infrahaus/credentials
 
 set -eo pipefail
 

--- a/infra/lxc/templates/web3-dev/container-configs/scripts/52-opencode.sh
+++ b/infra/lxc/templates/web3-dev/container-configs/scripts/52-opencode.sh
@@ -6,7 +6,7 @@
 # - Random secure password
 # - Web interface on port 8082
 #
-# Credentials stored in /etc/pve-home-lab/credentials
+# Credentials stored in /etc/infrahaus/credentials
 # Note: OpenCode is optional - failure will not halt container setup
 
 set -eo pipefail

--- a/infra/lxc/templates/web3-dev/container-configs/scripts/99-post-setup.sh
+++ b/infra/lxc/templates/web3-dev/container-configs/scripts/99-post-setup.sh
@@ -106,7 +106,7 @@ log_info "✓ Temporary files cleaned"
 CONTAINER_IP=$(hostname -I | awk '{print $1}')
 
 # Load generated credentials
-CREDS_FILE="/etc/pve-home-lab/credentials"
+CREDS_FILE="/etc/infrahaus/credentials"
 if [[ -f "$CREDS_FILE" ]]; then
     # shellcheck disable=SC1090
     source "$CREDS_FILE"
@@ -147,7 +147,7 @@ cat << EOF
 
 🔐 View Credentials:
    
-   cat /etc/pve-home-lab/credentials
+   cat /etc/infrahaus/credentials
 
 🔑 Change Passwords:
    
@@ -190,7 +190,7 @@ cat << EOF
    4. Start coding!
 
 📚 Repository:
-   https://github.com/kethalia/pve-home-lab
+   https://github.com/kethalia/infrahaus
 
 ═══════════════════════════════════════════════════════════
 

--- a/infra/lxc/templates/web3-dev/container.sh
+++ b/infra/lxc/templates/web3-dev/container.sh
@@ -7,8 +7,8 @@
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/2026-02-02/misc/build.func)
 # Copyright (c) 2026 kethalia
 # Author: kethalia
-# License: MIT | https://github.com/kethalia/pve-home-lab/raw/main/LICENSE
-# Source: https://github.com/kethalia/pve-home-lab
+# License: MIT | https://github.com/kethalia/infrahaus/raw/main/LICENSE
+# Source: https://github.com/kethalia/infrahaus
 
 # Detect which branch this script is running from
 # This allows testing on feature branches by setting SCRIPT_BRANCH env var
@@ -21,7 +21,7 @@ if [[ -f "$(dirname "${BASH_SOURCE[0]:-$0}")/template.conf" ]]; then
   source "$(dirname "${BASH_SOURCE[0]:-$0}")/template.conf"
 else
   # Remote execution via curl
-  source <(curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/${SCRIPT_BRANCH}/infra/lxc/templates/web3-dev/template.conf)
+  source <(curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/${SCRIPT_BRANCH}/infra/lxc/templates/web3-dev/template.conf)
 fi
 
 # Template metadata
@@ -95,7 +95,7 @@ build_container
 msg_info "Running Web3 Dev Container configuration"
 
 # Configuration (must be provided via environment variables)
-REPO_URL="${REPO_URL:-https://github.com/kethalia/pve-home-lab.git}"
+REPO_URL="${REPO_URL:-https://github.com/kethalia/infrahaus.git}"
 REPO_BRANCH="${REPO_BRANCH:-${SCRIPT_BRANCH}}"  # Use same branch as container.sh
 
 # The install script needs FUNCTIONS_FILE_PATH (ProxmoxVE framework functions)
@@ -112,7 +112,7 @@ set -euo pipefail
 export FUNCTIONS_FILE_PATH="$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/install.func)"
 
 # Download the install script to a file
-curl -fsSL https://raw.githubusercontent.com/kethalia/pve-home-lab/BRANCH_PLACEHOLDER/infra/lxc/scripts/install-lxc-template.sh > /tmp/install-lxc-template.sh
+curl -fsSL https://raw.githubusercontent.com/kethalia/infrahaus/BRANCH_PLACEHOLDER/infra/lxc/scripts/install-lxc-template.sh > /tmp/install-lxc-template.sh
 chmod +x /tmp/install-lxc-template.sh
 
 # Execute it

--- a/infra/lxc/tests/fixtures/config.env
+++ b/infra/lxc/tests/fixtures/config.env
@@ -1,7 +1,7 @@
 # Test configuration for config-manager
 # Used by unit and integration tests
 
-CONFIG_REPO_URL="https://github.com/kethalia/pve-home-lab.git"
+CONFIG_REPO_URL="https://github.com/kethalia/infrahaus.git"
 CONFIG_BRANCH="main"
 CONFIG_PATH="infra/lxc/templates/web3-dev/container-configs"
 CONFIG_HELPER_PATH="infra/lxc/scripts/config-manager"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pve-home-lab",
+  "name": "infrahaus",
   "private": true,
   "scripts": {
     "dev": "turbo dev",


### PR DESCRIPTION
## Summary

Complete brand refresh from `pve-home-lab` to `infrahaus` across the entire codebase.

### What Changed

| Before | After |
|--------|-------|
| `pve-home-lab` | `infrahaus` |
| `PVE Home Lab` | `Infrahaus` |
| `/etc/pve-home-lab/credentials` | `/etc/infrahaus/credentials` |
| `github.com/kethalia/pve-home-lab` | `github.com/kethalia/infrahaus` |

### Files Updated (29 total)

**Core Identity:**
- ✅ `package.json` - Updated package name
- ✅ `README.md` - Updated title, directory structure, clone URLs

**Documentation Site:**
- ✅ Web app metadata, titles, and navigation
- ✅ All MDX documentation files
- ✅ GitHub URLs and credential paths

**Infrastructure:**
- ✅ All shell scripts in `infra/lxc/`
- ✅ Container deployment scripts
- ✅ Config manager and systemd services
- ✅ Documentation and test fixtures

### Breaking Changes

⚠️ **Credential Path Change**: Existing LXC containers will need migration from `/etc/pve-home-lab/credentials` to `/etc/infrahaus/credentials`

### Quality Assurance

- ✅ No remaining `pve-home-lab` references (except intentional placeholders)
- ✅ JSON syntax validated
- ✅ Shell script syntax verified
- ✅ ShellCheck passed with no new warnings

### Next Steps

1. Merge this PR
2. Rename GitHub repository to `infrahaus`
3. Update local working directory name
4. Consider migration docs for existing users

The tagline *"Self-hosted infrastructure as code"* remains unchanged and fits perfectly with the new brand.