### PR TITLE
feat(03.5-08): Dashboard multi-node support — node badges, filtering, graceful degradation

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -61,7 +61,8 @@ Issues: #80, #81, #82
 ### Phase 03.5: Infrastructure Refactor
 
 **Goal:** Remove stored container passwords, cache VMIDs from Proxmox via Redis, and replace env-var auth with multi-user DB-stored credentials
-**Status:** In progress (7/8 plans complete)
+**Status:** Complete
+**Completed:** 2026-02-23
 **Depends on:** Phase 03
 **Plans:** 8 plans
 
@@ -86,7 +87,7 @@ Plans:
 - [x] 03.5-05-PLAN.md — Worker + service logs route migration to DB-based auth
 - [x] 03.5-06-PLAN.md — Settings page UI (/settings/nodes)
 - [x] 03.5-07-PLAN.md — Wizard updates (password removal, VMID validation, node selector)
-- [ ] 03.5-08-PLAN.md — Dashboard updates (node badge, filtering, no-nodes banner)
+- [x] 03.5-08-PLAN.md — Dashboard updates (node badge, filtering, no-nodes banner)
 
 ---
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,12 +3,12 @@
 ## Current Position
 
 **Project:** LXC Template Manager Dashboard (apps/dashboard)
-**Phase:** 03.6-remove-container-db — Complete ✓
-**Plan:** 6 of 6 in current phase (all complete)
-**Status:** Phase complete — All 6 plans executed
-**Last activity:** 2026-02-22 — Completed 03.6-04-PLAN.md (schema removal, final plan)
+**Phase:** 03.5-infrastructure-refactor — Complete ✓
+**Plan:** 8 of 8 in current phase (all complete)
+**Status:** Phase complete — All 8 plans executed
+**Last activity:** 2026-02-23 — Completed 03.5-08-PLAN.md (dashboard multi-node support)
 
-Progress: █████████████████ 78% (38/49 plans)
+Progress: █████████████████ 80% (39/49 plans)
 
 ## Completed Work
 
@@ -127,6 +127,13 @@ Progress: █████████████████ 78% (38/49 plans)
 - Node selector shows default node with "(default)" label, allows changing
 - Wizard page shows NoNodesBanner when no nodes configured
 - VMID cache refreshed server-side on wizard page load
+
+**03.5-08 — Dashboard multi-node support** ✓
+
+- Node badge (shadcn Badge outline) on container cards showing which node each container belongs to
+- Create Container button disabled when no nodes configured
+- Node filtering in container grid (multi-node only, "All Nodes" default)
+- NoNodesBanner on dashboard with link to settings
 
 ### Phase 3.6: Remove Container from Database ✓
 
@@ -280,10 +287,12 @@ Progress: █████████████████ 78% (38/49 plans)
 - Services API route supports `?discover=true` — cache-first pattern with SSH auto-discovery fallback when cache is empty
 - container-card.tsx converted to client component ("use client") for useContainerServices hook. Shows Skeleton loading state while services load.
 - services-tab.tsx uses useQueryClient for cache invalidation on manual refresh instead of hand-rolled useEffect
+- **NEXT PRIORITY: Decouple auth from Proxmox** — Login should be independent (local accounts or separate provider). Proxmox nodes added post-login as configuration. Makes no-nodes the real first-login experience.
 
 ## Pending Work
 
-- Phase 3.5: Plan 08 remaining (dashboard updates: node badge, filtering, no-nodes banner)
+- **NEXT: Decouple authentication from Proxmox** — auth should be independent so users can log in without a Proxmox node, then add nodes as configuration step
+- Phase 3.5: Complete ✓ — All 8 plans executed
 - Phase 3.6: Complete ✓ — All 6 plans executed
 - Phase 5: Web UI & Monitoring (#87-88)
 - Phase 6: CI/CD & Deployment (#89-90)
@@ -302,6 +311,6 @@ Progress: █████████████████ 78% (38/49 plans)
 ## Session Continuity
 
 Last session: 2026-02-23
-Stopped at: Phase 03.6 TanStack Query service auto-loading committed + pushed to PR #124
+Stopped at: Completed 03.5-08-PLAN.md (Phase 3.5 complete)
 Resume file: None
-Next step: Phase 3.5 Plan 08 (dashboard updates) or Phase 5 (Web UI & Monitoring)
+Next step: Decouple authentication from Proxmox, then Phase 5 (Web UI & Monitoring)

--- a/.planning/phases/03.5-infrastructure-refactor/03.5-08-SUMMARY.md
+++ b/.planning/phases/03.5-infrastructure-refactor/03.5-08-SUMMARY.md
@@ -1,0 +1,117 @@
+---
+phase: 03.5-infrastructure-refactor
+plan: 08
+subsystem: ui
+tags: [dashboard, node-badge, shadcn-badge, node-filtering, session-auth, multi-node]
+
+# Dependency graph
+requires:
+  - phase: 03.5-04
+    provides: "getContainersWithStatus(userId) with per-node parallel fetch"
+  - phase: 03.5-06
+    provides: "Settings page for node CRUD"
+  - phase: 03.6-05
+    provides: "Dashboard loading skeletons, empty states, node failure banners"
+provides:
+  - "Node badge on container cards (Badge variant=outline)"
+  - "Disabled Create Container button when no nodes configured"
+  - "Node filtering in container grid (multi-node only)"
+  - "NoNodesBanner on dashboard when no nodes exist"
+affects: ["05-web-ui-monitoring", "auth-decoupling"]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Conditional disabled button vs asChild Link pattern for graceful degradation"
+
+key-files:
+  created: []
+  modified:
+    - "apps/dashboard/src/app/(dashboard)/page.tsx"
+    - "apps/dashboard/src/components/containers/container-card.tsx"
+
+key-decisions:
+  - "Node badge always shown (even single-node) — simpler, consistent, forward-compatible with multi-node"
+  - "Create Container button disabled (not hidden) when no nodes — clear affordance"
+  - "Decoupling auth from Proxmox is the immediate next priority — current login flow auto-provisions nodes, making no-nodes state rare but the defensive guard is forward-looking"
+
+patterns-established:
+  - "Disabled button pattern: use disabled prop without asChild when action unavailable, vs asChild Link when available"
+
+# Metrics
+duration: 28min
+completed: 2026-02-23
+---
+
+# Phase 3.5 Plan 08: Dashboard Multi-Node Support Summary
+
+**Node badge (shadcn Badge outline) on container cards, disabled Create Container when no nodes, session-aware data fetching verified**
+
+## Performance
+
+- **Duration:** 28 min
+- **Started:** 2026-02-23T18:18:20Z
+- **Completed:** 2026-02-23T18:46:31Z
+- **Tasks:** 3 (2 auto + 1 human-verify checkpoint)
+- **Files modified:** 2
+
+## Accomplishments
+- Container cards display node name as a subtle outline Badge (shadcn) next to VMID
+- Create Container button disabled when user has no Proxmox nodes configured
+- Full dashboard verified: session-aware data fetching, node filtering, NoNodesBanner
+- Identified that auth decoupling from Proxmox should be the next priority
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Update dashboard page for session-aware data fetching** - `798119a` (feat)
+2. **Task 2: Add node badge to container cards** - `239612f` (feat)
+3. **Task 3: Human verification** - checkpoint (approved)
+
+## Files Created/Modified
+- `apps/dashboard/src/app/(dashboard)/page.tsx` - Disabled Create Container button when no nodes; existing session-aware fetch confirmed
+- `apps/dashboard/src/components/containers/container-card.tsx` - Added shadcn Badge (outline) for node name display
+
+## Decisions Made
+- **Node badge always visible** — even for single-node users, the badge shows. Simpler implementation and forward-compatible with multi-node. Badge is subtle (outline variant, 10px font).
+- **Disabled button, not hidden** — Create Container button shows disabled state when no nodes, giving clear visual feedback rather than hiding the affordance.
+- **Auth decoupling from Proxmox is next priority** — Per user decision, the authentication flow should be independent of Proxmox nodes. Current login auto-provisions a node, making the no-nodes state unreachable in practice. Decoupling auth makes no-nodes the real first-login experience.
+
+## Deviations from Plan
+
+### Pre-existing Implementation
+
+Most of the planned work was already implemented by prior plans:
+- **page.tsx**: Session-aware data fetching, NoNodesBanner, nodeNames extraction — all from plans 03.5-04 and 03.6-05
+- **layout.tsx**: Already calls getSessionData() and passes username to AppSidebar — no changes needed
+- **container-grid.tsx**: Node filtering (multi-node only) already fully implemented in plan 03.6-05
+- **container-dashboard.tsx**: File doesn't exist — the dashboard is composed of page.tsx + ContainerGrid + ContainerCard
+
+**Actual new work:**
+1. Disabled Create Container button when no nodes (page.tsx)
+2. Replaced plain-text node name with shadcn Badge on container cards (container-card.tsx)
+
+---
+
+**Total deviations:** 0 auto-fixed
+**Impact on plan:** Plan scope was largely already complete from prior work. New additions are the Badge component and disabled button state.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Phase 3.5 is now **complete** (8/8 plans)
+- **Immediate next priority: Decouple authentication from Proxmox** — per user decision, auth should be independent so users can log in without a Proxmox node, then add nodes as a configuration step
+- All container dashboard features operational: node badges, filtering, graceful degradation
+- Ready for Phase 05 (Web UI & Monitoring) after auth decoupling
+
+## Self-Check: PASSED
+
+---
+*Phase: 03.5-infrastructure-refactor*
+*Completed: 2026-02-23*

--- a/apps/dashboard/src/app/(dashboard)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/page.tsx
@@ -41,12 +41,19 @@ export default async function DashboardPage() {
             Manage your LXC containers and templates
           </p>
         </div>
-        <Button asChild size="sm">
-          <Link href="/containers/new">
+        {hasNodes ? (
+          <Button asChild size="sm">
+            <Link href="/containers/new">
+              <Plus className="size-4" />
+              Create Container
+            </Link>
+          </Button>
+        ) : (
+          <Button size="sm" disabled>
             <Plus className="size-4" />
             Create Container
-          </Link>
-        </Button>
+          </Button>
+        )}
       </div>
 
       {!hasNodes && <NoNodesBanner />}
@@ -63,6 +70,8 @@ export default async function DashboardPage() {
           />
         </>
       )}
+      {/* Template browsing and non-Proxmox features still work even without nodes.
+          Container operations are disabled via NoNodesBanner messaging. */}
     </div>
   );
 }

--- a/apps/dashboard/src/components/containers/container-card.tsx
+++ b/apps/dashboard/src/components/containers/container-card.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Server, Loader2 } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusBadge } from "./status-badge";
@@ -98,8 +99,12 @@ export function ContainerCard({
         </div>
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span>VMID {vmid}</span>
-          <span>·</span>
-          <span>{node.name}</span>
+          <Badge
+            variant="outline"
+            className="px-1.5 py-0 text-[10px] font-normal"
+          >
+            {node.name}
+          </Badge>
           {template && (
             <>
               <span>·</span>


### PR DESCRIPTION
## Summary

- Add shadcn `Badge` (outline variant) on container cards showing which Proxmox node each container belongs to
- Disable "Create Container" button when user has no nodes configured (graceful degradation)
- Node filtering in container grid already implemented (multi-node only, "All Nodes" default)

## Phase 3.5 Complete

This is the final plan (8/8) of Phase 3.5: Infrastructure Refactor. All multi-user, multi-node infrastructure is now in place.

**Next priority:** Decouple authentication from Proxmox — auth should be independent so users can log in without a Proxmox node, then add nodes as a configuration step.

## Files Changed

- `apps/dashboard/src/app/(dashboard)/page.tsx` — Conditional disabled Create Container button when no nodes
- `apps/dashboard/src/components/containers/container-card.tsx` — Node name Badge (outline) replacing plain text
- `.planning/` — SUMMARY, STATE, ROADMAP updates